### PR TITLE
Version 0.2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 SeparateRecords
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An _extremely_ simple way to mock `window.fetch`.
 
 [Read the documentation][docs], or see "Usage" below.
 
-[docs]: https://doc.deno.land/https/deno.land/x/mock_fetch@0.2.0
+[docs]: https://doc.deno.land/https/deno.land/x/mock_fetch/mod.ts
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # deno_mock_fetch
 
-An _extremely_ simple `window.fetch` mock for Deno.
+An _extremely_ simple way to mock `window.fetch`.
 
-## Get started
+[Read the documentation][docs], or see "Usage" below.
 
-This library is designed to get you going as fast as possible with the minimum
-code.
+[docs]: https://doc.deno.land/https/deno.land/x/mock_fetch@0.2.0
+
+## Usage
 
 ### 1. Setup
 
 Import the library and install the mock. Any fetches after calling `install()`
-will throw an error if you haven't mocked the route.
+will throw an error if you haven't explicitly added a mock for that route.
 
 ```typescript
 import * as mf from "https://deno.land/x/mock_fetch@0.2.0/mod.ts";
@@ -19,11 +20,17 @@ import * as mf from "https://deno.land/x/mock_fetch@0.2.0/mod.ts";
 mf.install();
 ```
 
+<br>
+
 ### 2. Mocking routes
 
 Call `mock` with a route (optionally starting with a method specifier, eg.
 `DELETE@`) and a function (can be async). Whenever that route is fetched, the
 function will be executed and the response will be returned.
+
+The route uses [path-to-regexp], which allows you to use wildcard parameters.
+
+[path-to-regexp]: https://github.com/pillarjs/path-to-regexp#parameters
 
 ```typescript
 mf.mock("GET@/api/hello/:name", (_req, match) => {
@@ -35,6 +42,8 @@ mf.mock("GET@/api/hello/:name", (_req, match) => {
 const res = await fetch("https://localhost:1234/api/hello/SeparateRecords");
 const text = await res.text(); //=> "Hello, SeparateRecords!"
 ```
+
+<br>
 
 ### 3. Teardown
 
@@ -54,6 +63,8 @@ To restore the original `fetch`, call `uninstall`.
 ```typescript
 mf.uninstall();
 ```
+
+<br>
 
 ## Advanced usage
 
@@ -88,7 +99,12 @@ myKy.put("blog/posts", {
 
 You can destructure it, too.
 
-## Documentation
+<br>
 
-The documentation is available at
-[doc.deno.land/https/deno.land/x/mock_fetch@0.2.0](https://doc.deno.land/https/deno.land/x/mock_fetch@0.2.0).
+## Credits
+
+**[@eliassjogreen]**'s tiny router ([source][router]) does the bulk of the work.
+It's general purpose, but works great for Deno Deploy.
+
+[@eliassjogreen]: https://github.com/eliassjogreen
+[router]: https://crux.land/router@0.0.4

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ function will be executed and the response will be returned.
 
 The route uses [path-to-regexp], which allows you to use wildcard parameters.
 
+**Only the path name will be used to match a handler**, so you can use literally
+anything for the host when fetching.
+
 [path-to-regexp]: https://github.com/pillarjs/path-to-regexp#parameters
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ import ky from "https://cdn.skypack.dev/ky?dts";
 // This object can also be destructured.
 const mockFetch = mf.sandbox();
 
-// Create a ky instance that uses mocked fetch without ever touching the global
+// Make a ky instance that uses mocked fetch - never touching the global fetch.
+// Using a prefix URL means you won't need to write the URL every time.
 const myKy = ky.extend({
   fetch: mockFetch.fetch,
-  // Using a prefix URL means you won't need to write the URL every time
   prefixUrl: "https://anyurlyouwant.com",
 });
 

--- a/mod.ts
+++ b/mod.ts
@@ -137,4 +137,5 @@ export const install = () => {
  */
 export const uninstall = () => {
   globalThis.fetch = originalFetch;
+  reset();
 };

--- a/test.ts
+++ b/test.ts
@@ -181,3 +181,20 @@ Deno.test({
     mf.uninstall();
   },
 });
+
+Deno.test({
+  name: "uninstall resets handlers",
+  async fn() {
+    mf.install();
+    mf.mock("/", () => new Response());
+
+    // don't need the response, just need to know this doesn't throw
+    await fetch("https://nice.dev/");
+
+    mf.uninstall();
+
+    await assertThrowsAsync(async () => {
+      await fetch("https://nice.dev/");
+    });
+  },
+});


### PR DESCRIPTION
0.2.0 is backwards compatible - you can bump the version number in your deps and it'll work.

## Adds

- **`sandbox`: local state!**\
  The globals are created using this function too.
  This allows you to have multiple separate mocks, which you might want for concurrent tests.

## Improves

- **Introduction**\
  The readme is a little more legible. More whitespace, better wording.

## Fixes

- **`uninstall` now removes handlers from the global mock**\
  This was always the intended behaviour, but I forgot to actually... do that.